### PR TITLE
ADM remediating 2 vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.33</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>


### PR DESCRIPTION
Vulnerabilities:
* CVE-2021-44832: org.apache.logging.log4j:log4j-core:2.17.0
* CVE-2022-1471: org.yaml:snakeyaml:1.33

Dependencies upgraded:
* org.apache.logging.log4j:log4j-core:2.17.0 -> 2.17.1
* org.yaml:snakeyaml:1.33 -> 2.0

Auto-merge is disabled