### PR TITLE
ADM remediating 4 vulnerable artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,22 +58,22 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.33</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7</version>
+      <version>2.13.4.1</version>
     </dependency>
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>9.7</version>
+      <version>17.5</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaacrsaiiiaiviomskcvlop7ej7qjyqhu4xcdjuid452syb72byxgoa/runs/ocid1.admremediationrun.oc1.iad.amaaaaaacrsaiiiahhx4lrjhyxgvqpjeoad5jktrvynzaouk6jdnb6zhbfxq/stages/DETECT)

* demo:NativeHelloWorld:1.0-SNAPSHOT
  * com.fasterxml.jackson.core:jackson-databind:2.12.7
    * CVE-2022-42003
    * CVE-2022-42004
  * com.graphql-java:graphql-java:9.7
    * CVE-2022-37734
    * CVE-2023-28867
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.7
      * CVE-2022-42003
      * CVE-2022-42004
  * org.yaml:snakeyaml:1.33
    * CVE-2022-1471

## Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaacrsaiiiaiviomskcvlop7ej7qjyqhu4xcdjuid452syb72byxgoa/runs/ocid1.admremediationrun.oc1.iad.amaaaaaacrsaiiiahhx4lrjhyxgvqpjeoad5jktrvynzaouk6jdnb6zhbfxq/stages/RECOMMEND)

* com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.13.4.1
* com.graphql-java:graphql-java:9.7 -> 17.5
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.yaml:snakeyaml:1.33 -> 2.0

Auto-merge is disabled.